### PR TITLE
feat: Make sashRender prop optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface ISplitProps extends HTMLElementProps {
      * Only support controlled mode, so it's required
      */
     sizes: (string | number)[];
-    sashRender: (index: number, active: boolean) => React.ReactNode;
+    sashRender?: (index: number, active: boolean) => React.ReactNode;
     onChange: (sizes: number[]) => void;
     onDragStart?: (e: MouseEvent) => void;
     onDragEnd?: (e: MouseEvent) => void;


### PR DESCRIPTION
Sash render prop is already given a default value when using `SplitPane` component so I wanted to make it optional at the type level as well. See [issue](https://github.com/yyllff/split-pane-react/issues/12).