### PR TITLE
Preserve percent and auto sizes

### DIFF
--- a/src/SplitPane.tsx
+++ b/src/SplitPane.tsx
@@ -13,7 +13,8 @@ import {
     sashDisabledClassName,
     sashHorizontalClassName,
     sashVerticalClassName,
-    assertsSize
+    assertsSize,
+    invertSize
 } from './base';
 import { IAxis, ISplitProps, IPaneConfigs, ICacheSizes } from './types';
 
@@ -137,9 +138,14 @@ const SplitPane = ({
             distanceX = rightBorder;
         }
 
-        const nextSizes = [...sizes];
-        nextSizes[i] += distanceX;
-        nextSizes[i + 1] -= distanceX;
+        const nextSizes: (string | number)[] = [...propSizes];
+
+        nextSizes[i] = invertSize(propSizes[i], sizes[i] + distanceX, wrapSize);
+        nextSizes[i + 1] = invertSize(
+          propSizes[i + 1],
+          sizes[i + 1] - distanceX,
+          wrapSize
+        );
 
         onChange(nextSizes);
     }, [paneLimitSizes, onChange]);

--- a/src/base.ts
+++ b/src/base.ts
@@ -86,3 +86,14 @@ export function assertsSize (
     if (size.endsWith('px')) return +size.replace('px', '');
     return defaultValue;
 }
+
+export function invertSize(
+  currentSize: string | number | undefined,
+  nextSize: number,
+  sum: number
+) {
+  if (currentSize == "auto") return "auto";
+  if (!isFinite(nextSize)) return nextSize;
+  if (typeof currentSize == "string" && currentSize.endsWith("%")) return (nextSize / sum) * 100 + "%";
+  return nextSize;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export interface ISplitProps extends HTMLElementProps {
      */
     sizes: (string | number)[];
     sashRender: (index: number, active: boolean) => React.ReactNode;
-    onChange: (sizes: number[]) => void;
+    onChange: (sizes: (string | number)[]) => void;
     onDragStart?: (e: MouseEvent) => void;
     onDragEnd?: (e: MouseEvent) => void;
     className?: string;
@@ -45,7 +45,7 @@ export interface ISplitProps extends HTMLElementProps {
     /**
      * Specify the size fo resizer
      *
-     * defualt size is 4px
+     * default size is 4px
      */
     resizerSize?: number;
 }


### PR DESCRIPTION
This could be considered a breaking change so LMK if you want to make this optional or not.

If you split a pane with percentages, you ought to be able to keep those percentages across resizes; i.e. if a pane has 33% and I shrink it to 25%, I should get that in the callback instead of the pixel size. That way, when I resize the entire page, the pane still takes up 25%.